### PR TITLE
Play 2.7.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Set up redis cluster with docker.
 $ docker run  -e "IP=0.0.0.0" -p7000:7000 -p7001:7001 -p7002:7002 --hostname redis-cluster  grokzen/redis-cluster:latest
 ```
 
-Run Play app server.
+Run Play app server in the redis module.
 
 ```shell
-$ sbt ~run
+$ sbt ~redis/run
 ```
 
 Visit [http://localhost:9000/sso/mc/dev-login](http://localhost:9000/sso/mc/dev-login) to view mock login page.

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,8 @@ lazy val redis = (project in file("stargate-redis")).
     name := "stargate-redis",
     description := "Stargate Scala Play module with Redis as session store",
 
+    javaOptions += "-Dconfig.resource=stargate-redis.default.conf",
+
     libraryDependencies ++= Seq(
       jedis
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.4")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")

--- a/stargate-redis/conf/stargate-redis.default.conf
+++ b/stargate-redis/conf/stargate-redis.default.conf
@@ -1,4 +1,4 @@
-include "stargate-core.default.conf"
+include "stargate-core.application.conf"
 
 play.modules.enabled += com.salesforce.mce.stargate.modules.StargateRedisModule
 


### PR DESCRIPTION
**Why is this pull request being made ?**
Stargate has beens using play version 2.6.12. Its time to support 2.7.x releases

**What does this pull request do?**
1. Correct / Change development instructions in ReadMe
2. Redis module uses stargate-redis.default.conf as play configuration. Previously it did not have an application.conf so the appserver would throw an error if one tried to access a route on it.
3. Points the stargate-redis.default.conf to include the stargate-core.application.conf instead of stargate-core.default.conf (because we were skipping the configuration of the play application server by just including stargate-core.default.conf)
3. Update play version to 2.7.4