### PR TITLE
Support for Play 2.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Set up redis cluster with docker.
 $ docker run  -e "IP=0.0.0.0" -p7000:7000 -p7001:7001 -p7002:7002 --hostname redis-cluster  grokzen/redis-cluster:latest
 ```
 
-Run Play app server.
+Run Play app server in the redis module.
 
 ```shell
-$ sbt ~run
+$ sbt ~redis/run
 ```
 
 Visit [http://localhost:9000/sso/mc/dev-login](http://localhost:9000/sso/mc/dev-login) to view mock login page.

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,8 @@ lazy val redis = (project in file("stargate-redis")).
     name := "stargate-redis",
     description := "Stargate Scala Play module with Redis as session store",
 
+    javaOptions += "-Dconfig.resource=stargate-redis.default.conf",
+
     libraryDependencies ++= Seq(
       jedis
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.3.1")

--- a/stargate-redis/conf/stargate-redis.default.conf
+++ b/stargate-redis/conf/stargate-redis.default.conf
@@ -1,4 +1,4 @@
-include "stargate-core.default.conf"
+include "stargate-core.application.conf"
 
 play.modules.enabled += com.salesforce.mce.stargate.modules.StargateRedisModule
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13.4"
+version in ThisBuild := "0.14.0"


### PR DESCRIPTION
**Why is this pull request being made?**
This pull request is being made for supporting play 2.8.0

**What does this pull request do?**
1. Use stargate-redis.default.conf as play configuration in redis module
2. Include stargate-core.application.conf in stargate-redis.default.conf for bringing in play configuration
3. Update play version to 2.8.0
4. Update development instructions in ReadMe.md