### PR TITLE
FIX: Set maxAge = 0 for Play Session Cookie upon logout

### DIFF
--- a/stargate-core/app/com/salesforce/mce/stargate/controllers/McSsoController.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/controllers/McSsoController.scala
@@ -64,6 +64,7 @@ class McSsoController @Inject() (
     val result = Ok.withCookies(Cookie(
       name = sessionConfig.cookieName,
       value = "",
+      maxAge = Some(0),   // ensure cookie expires immediately, if not discarded
       secure = sessionConfig.secure,
       sameSite = sessionConfig.sameSite
     ))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.14.2"
+version in ThisBuild := "0.14.3"


### PR DESCRIPTION
This PR fixes the issue of the play session cookie not being discarded upon logon.