### PR TITLE
Add mcAccessToken and mcAccessTokenExp as optional McSsoJwtRequestRest items.

### DIFF
--- a/stargate-core/app/com/salesforce/mce/stargate/controllers/McSsoController.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/controllers/McSsoController.scala
@@ -64,7 +64,7 @@ class McSsoController @Inject() (
     val result = Ok.withCookies(Cookie(
       name = sessionConfig.cookieName,
       value = "",
-      maxAge = Some(0),   // ensure cookie expires immediately, if not discarded
+      maxAge = Some(0), // ensure cookie expires immediately, if not discarded
       secure = sessionConfig.secure,
       sameSite = sessionConfig.sameSite
     ))

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -48,6 +48,18 @@ object McSsoJwtRequest {
   )(McSsoJwtRequest.apply _)
 }
 
+/** Encapsulates Marketing Cloud REST based claims. Two optional params (mcAccessToken & mcAccessTokenExp) have been
+ *  added as of version 0.14.5 which are not outlined in the Field Reference for Decoded JWT:
+ *  https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-app-development.meta/mc-app-development/explanation-decoded-jwt.htm
+ *  These two jwt claim properties must be injected and the JWT resigned to become available and are not part
+ *  of the standard JWT Marketing Cloud provides upon login.
+ *
+ *  @param authEndpoint The Marketing Cloud authentication endpoint
+ *  @param apiEndpointBase The Marketing Cloud API endpoint base
+ *  @param refreshToken A token to request a Marketing Cloud Access Token when used with an app's clientId and clientSecret
+ *  @param mcAccessToken [Optional] Marketing Cloud Access token to be captured if injected into the JWT REST claim.
+ *  @param mcAccessTokenExp [Optional] expiry time in seconds for the Marketing Cloud Access token if provided.
+ */
 case class McSsoJwtRequestRest(
   authEndpoint: String,
   apiEndpointBase: String,

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -52,8 +52,8 @@ case class McSsoJwtRequestRest(
   authEndpoint: String,
   apiEndpointBase: String,
   refreshToken: String,
-  mcAccessToken: Option[String],
-  mcAccessTokenExp: Option[Long]
+  mcAccessToken: Option[String] = None,
+  mcAccessTokenExp: Option[Long] = None
 )
 
 object McSsoJwtRequestRest {

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -64,8 +64,8 @@ case class McSsoJwtRequestRest(
   authEndpoint: String,
   apiEndpointBase: String,
   refreshToken: String,
-  mcAccessToken: Option[String] = None,
-  mcAccessTokenExp: Option[Long] = None
+  mcAccessToken: Option[String],
+  mcAccessTokenExp: Option[Long]
 )
 
 object McSsoJwtRequestRest {

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -52,7 +52,8 @@ case class McSsoJwtRequestRest(
   authEndpoint: String,
   apiEndpointBase: String,
   refreshToken: String,
-  mcAccessToken: Option[String]
+  mcAccessToken: Option[String],
+  mcAccessTokenExp: Option[Long]
 )
 
 object McSsoJwtRequestRest {
@@ -60,7 +61,8 @@ object McSsoJwtRequestRest {
     (JsPath \ "authEndpoint").read[String] and
     (JsPath \ "apiEndpointBase").read[String] and
     (JsPath \ "refreshToken").read[String] and
-    (JsPath \ "mcAccessToken").readNullable[String]
+    (JsPath \ "mcAccessToken").readNullable[String] and
+    (JsPath \ "mcAccessTokenExp").readNullable[Long]
   )(McSsoJwtRequestRest.apply _)
 }
 

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -34,8 +34,7 @@ case class McSsoJwtRequest(
   user: McSsoJwtRequestUser,
   organization: McSsoJwtRequestOrganization,
   application: McSsoJwtRequestApplication,
-  query: Option[McSsoJwtRequestQuery],
-  additionalClaims: Option[McSsoJwtRequestAdditionalClaims]
+  query: Option[McSsoJwtRequestQuery]
 )
 
 object McSsoJwtRequest {
@@ -45,22 +44,23 @@ object McSsoJwtRequest {
     (JsPath \ "user").read[McSsoJwtRequestUser] and
     (JsPath \ "organization").read[McSsoJwtRequestOrganization] and
     (JsPath \ "application").read[McSsoJwtRequestApplication] and
-    (JsPath \ "query").readNullable[McSsoJwtRequestQuery] and
-    (JsPath \ "additionalClaims").readNullable[McSsoJwtRequestAdditionalClaims]
+    (JsPath \ "query").readNullable[McSsoJwtRequestQuery]
   )(McSsoJwtRequest.apply _)
 }
 
 case class McSsoJwtRequestRest(
   authEndpoint: String,
   apiEndpointBase: String,
-  refreshToken: String
+  refreshToken: String,
+  mcAccessToken: Option[String]
 )
 
 object McSsoJwtRequestRest {
   implicit val reads: Reads[McSsoJwtRequestRest] = (
     (JsPath \ "authEndpoint").read[String] and
     (JsPath \ "apiEndpointBase").read[String] and
-    (JsPath \ "refreshToken").read[String]
+    (JsPath \ "refreshToken").read[String] and
+    (JsPath \ "mcAccessToken").readNullable[String]
   )(McSsoJwtRequestRest.apply _)
 }
 
@@ -139,18 +139,4 @@ object McSsoJwtRequestQuery {
     (JsPath \ "deepLink").readNullable[String]
   )(McSsoJwtRequestQuery.apply _)
 }
-
-case class McSsoJwtRequestAdditionalClaims(
-  additionalClaims: Option[Map[String, String]],
-  no_opt: Option[String], //cannot get this solution to work without this placeholder
-)
-
-object McSsoJwtRequestAdditionalClaims {
-  implicit val reads: Reads[McSsoJwtRequestAdditionalClaims] = (
-    (JsPath \ "additionalClaims").readNullable[Map[String, String]] and
-    (JsPath \ "no_opt").readNullable[String]
-  )(McSsoJwtRequestAdditionalClaims.apply _)
-}
-
-
 

--- a/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/models/McSsoDecodedJwt.scala
@@ -34,7 +34,8 @@ case class McSsoJwtRequest(
   user: McSsoJwtRequestUser,
   organization: McSsoJwtRequestOrganization,
   application: McSsoJwtRequestApplication,
-  query: Option[McSsoJwtRequestQuery]
+  query: Option[McSsoJwtRequestQuery],
+  additionalClaims: Option[McSsoJwtRequestAdditionalClaims]
 )
 
 object McSsoJwtRequest {
@@ -44,7 +45,8 @@ object McSsoJwtRequest {
     (JsPath \ "user").read[McSsoJwtRequestUser] and
     (JsPath \ "organization").read[McSsoJwtRequestOrganization] and
     (JsPath \ "application").read[McSsoJwtRequestApplication] and
-    (JsPath \ "query").readNullable[McSsoJwtRequestQuery]
+    (JsPath \ "query").readNullable[McSsoJwtRequestQuery] and
+    (JsPath \ "additionalClaims").readNullable[McSsoJwtRequestAdditionalClaims]
   )(McSsoJwtRequest.apply _)
 }
 
@@ -137,3 +139,18 @@ object McSsoJwtRequestQuery {
     (JsPath \ "deepLink").readNullable[String]
   )(McSsoJwtRequestQuery.apply _)
 }
+
+case class McSsoJwtRequestAdditionalClaims(
+  additionalClaims: Option[Map[String, String]],
+  no_opt: Option[String], //cannot get this solution to work without this placeholder
+)
+
+object McSsoJwtRequestAdditionalClaims {
+  implicit val reads: Reads[McSsoJwtRequestAdditionalClaims] = (
+    (JsPath \ "additionalClaims").readNullable[Map[String, String]] and
+    (JsPath \ "no_opt").readNullable[String]
+  )(McSsoJwtRequestAdditionalClaims.apply _)
+}
+
+
+

--- a/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
@@ -54,7 +54,8 @@ class JwtUtilImpl @Inject() (config: Configuration) extends JwtUtil {
        |    "rest": {
        |      "authEndpoint": "https://auth-s8.exacttargetapis.com/v1/requestToken",
        |      "apiEndpointBase": "https://www.exacttargetapis.com/",
-       |      "refreshToken": "testrefreshtoken"
+       |      "refreshToken": "testrefreshtoken",
+       |      "mcAccessToken": "testAccessToken"
        |    },
        |    "organization": {
        |      "id": 8000000,
@@ -69,8 +70,7 @@ class JwtUtilImpl @Inject() (config: Configuration) extends JwtUtil {
        |      "redirectUrl": "https://cool-mc-app.mce.salesforce.com/",
        |      "features": {},
        |      "userPermissions": []
-       |    },
-       |    "additionalClaims": [{"some": "thing"}, {"another": "item"}]
+       |    }
        |  }
        |}
        """.stripMargin

--- a/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
@@ -69,7 +69,8 @@ class JwtUtilImpl @Inject() (config: Configuration) extends JwtUtil {
        |      "redirectUrl": "https://cool-mc-app.mce.salesforce.com/",
        |      "features": {},
        |      "userPermissions": []
-       |    }
+       |    },
+       |    "additionalClaims": [{"some": "thing"}, {"another": "item"}]
        |  }
        |}
        """.stripMargin

--- a/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
@@ -55,7 +55,8 @@ class JwtUtilImpl @Inject() (config: Configuration) extends JwtUtil {
        |      "authEndpoint": "https://auth-s8.exacttargetapis.com/v1/requestToken",
        |      "apiEndpointBase": "https://www.exacttargetapis.com/",
        |      "refreshToken": "testrefreshtoken",
-       |      "mcAccessToken": "testAccessToken"
+       |      "mcAccessToken": "testAccessToken",
+       |      "mcAccessTokenExp": 3555
        |    },
        |    "organization": {
        |      "id": 8000000,

--- a/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
+++ b/stargate-core/app/com/salesforce/mce/stargate/utils/JwtUtil.scala
@@ -19,7 +19,7 @@ trait JwtUtil {
 
   def mockJwt(): String
 
-  def mockDecodedJwt(): String
+  def mockDecodedJwt(shouldIncludeMCAccessToken: Boolean = true): String
 }
 
 @Singleton
@@ -33,51 +33,97 @@ class JwtUtilImpl @Inject() (config: Configuration) extends JwtUtil {
     case None       => Seq(secretKey)
   }
 
-  override def mockDecodedJwt: String =
-    s"""
-       | {
-       |  "exp": ${System.currentTimeMillis()},
-       |  "jti": "JT-IXXXXXXXXXXXXXXXXXXXXXXX",
-       |  "request": {
-       |    "claimsVersion": 2,
-       |    "user": {
-       |      "id": 1111118,
-       |      "email": "stargate@salesforce.com",
-       |      "culture": "en-US",
-       |      "timezone": {
-       |        "longName": "(GMT+08:00) Kuala Lumpur, Singapore",
-       |        "shortName": "GMT+8",
-       |        "offset": 8.0,
-       |        "dst": false
-       |      }
-       |    },
-       |    "rest": {
-       |      "authEndpoint": "https://auth-s8.exacttargetapis.com/v1/requestToken",
-       |      "apiEndpointBase": "https://www.exacttargetapis.com/",
-       |      "refreshToken": "testrefreshtoken",
-       |      "mcAccessToken": "testAccessToken",
-       |      "mcAccessTokenExp": 3555
-       |    },
-       |    "organization": {
-       |      "id": 8000000,
-       |      "enterpriseId": 9000000,
-       |      "dataContext": "enterprise",
-       |      "stackKey": "S8",
-       |      "region": "NA1"
-       |    },
-       |    "application": {
-       |      "id": "appidxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-       |      "package": "apppacka-gexx-xxxx-xxxx-xxxxxxxxxxxx.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-       |      "redirectUrl": "https://cool-mc-app.mce.salesforce.com/",
-       |      "features": {},
-       |      "userPermissions": []
-       |    }
-       |  }
-       |}
+  override def mockDecodedJwt(shouldIncludeMCAccessToken: Boolean = true): String =
+    shouldIncludeMCAccessToken match {
+      //when true - return the mcAccessToken and mcAccessTokenExp in the rest claim section
+      case true =>
+        s"""
+           | {
+           |  "exp": ${System.currentTimeMillis()},
+           |  "jti": "JT-IXXXXXXXXXXXXXXXXXXXXXXX",
+           |  "request": {
+           |    "claimsVersion": 2,
+           |    "user": {
+           |      "id": 1111118,
+           |      "email": "stargate@salesforce.com",
+           |      "culture": "en-US",
+           |      "timezone": {
+           |        "longName": "(GMT+08:00) Kuala Lumpur, Singapore",
+           |        "shortName": "GMT+8",
+           |        "offset": 8.0,
+           |        "dst": false
+           |      }
+           |    },
+           |    "rest": {
+           |      "authEndpoint": "https://auth-s8.exacttargetapis.com/v1/requestToken",
+           |      "apiEndpointBase": "https://www.exacttargetapis.com/",
+           |      "refreshToken": "testrefreshtoken",
+           |      "mcAccessToken": "testAccessToken",
+           |      "mcAccessTokenExp": 3555
+           |    },
+           |    "organization": {
+           |      "id": 8000000,
+           |      "enterpriseId": 9000000,
+           |      "dataContext": "enterprise",
+           |      "stackKey": "S8",
+           |      "region": "NA1"
+           |    },
+           |    "application": {
+           |      "id": "appidxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+           |      "package": "apppacka-gexx-xxxx-xxxx-xxxxxxxxxxxx.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+           |      "redirectUrl": "https://cool-mc-app.mce.salesforce.com/",
+           |      "features": {},
+           |      "userPermissions": []
+           |    }
+           |  }
+           |}
        """.stripMargin
 
+      //when false do not include the mcAccessToken or mcAccessTokenExp
+      case _ =>
+        s"""
+           | {
+           |  "exp": ${System.currentTimeMillis()},
+           |  "jti": "JT-IXXXXXXXXXXXXXXXXXXXXXXX",
+           |  "request": {
+           |    "claimsVersion": 2,
+           |    "user": {
+           |      "id": 1111118,
+           |      "email": "stargate@salesforce.com",
+           |      "culture": "en-US",
+           |      "timezone": {
+           |        "longName": "(GMT+08:00) Kuala Lumpur, Singapore",
+           |        "shortName": "GMT+8",
+           |        "offset": 8.0,
+           |        "dst": false
+           |      }
+           |    },
+           |    "rest": {
+           |      "authEndpoint": "https://auth-s8.exacttargetapis.com/v1/requestToken",
+           |      "apiEndpointBase": "https://www.exacttargetapis.com/",
+           |      "refreshToken": "testrefreshtoken"
+           |    },
+           |    "organization": {
+           |      "id": 8000000,
+           |      "enterpriseId": 9000000,
+           |      "dataContext": "enterprise",
+           |      "stackKey": "S8",
+           |      "region": "NA1"
+           |    },
+           |    "application": {
+           |      "id": "appidxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+           |      "package": "apppacka-gexx-xxxx-xxxx-xxxxxxxxxxxx.xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+           |      "redirectUrl": "https://cool-mc-app.mce.salesforce.com/",
+           |      "features": {},
+           |      "userPermissions": []
+           |    }
+           |  }
+           |}
+       """.stripMargin
+    }
+
   override def mockJwt(): String = {
-    encode(mockDecodedJwt)
+    encode(mockDecodedJwt(true))
   }
 
   override def decode(jwt: String): Try[(String, String, String)] = {

--- a/stargate-core/test/McSsoDecodedJwtSpec.scala
+++ b/stargate-core/test/McSsoDecodedJwtSpec.scala
@@ -1,0 +1,37 @@
+package integration
+
+import play.api.libs.json.Json
+import play.api.Configuration
+
+import com.typesafe.config.ConfigFactory
+import org.scalatestplus.play._
+
+import com.salesforce.mce.stargate.models.McSsoDecodedJwt
+import com.salesforce.mce.stargate.utils.JwtUtilImpl
+
+class McSsoDecodedJwtSpec extends PlaySpec {
+
+  "McSsoDecodedJwt with mcAccessToken in payload" should {
+    val jwtPayload = new JwtUtilImpl(Configuration(ConfigFactory.load())).mockDecodedJwt(true)
+
+    val jsonFormat = Json.parse(jwtPayload)
+    val decodedJwt = Json.fromJson[McSsoDecodedJwt](jsonFormat).get
+
+    "have a mcAccessToken and mcAccessTokenExp set " in {
+      decodedJwt.request.rest.mcAccessToken.get mustBe "testAccessToken"
+      decodedJwt.request.rest.mcAccessTokenExp.get mustBe 3555
+    }
+  }
+
+  "McSsoDecodedJwt without mcAccessToken in payload" should {
+    val jwtPayload = new JwtUtilImpl(Configuration(ConfigFactory.load())).mockDecodedJwt(false)
+
+    val jsonFormat = Json.parse(jwtPayload)
+    val decodedJwt = Json.fromJson[McSsoDecodedJwt](jsonFormat).get
+
+    "have a mcAccessToken and mcAccessTokenExp set to None" in {
+      decodedJwt.request.rest.mcAccessToken mustBe None
+      decodedJwt.request.rest.mcAccessTokenExp mustBe None
+    }
+  }
+}

--- a/stargate-redis/test/integration/McSsoControllerSpec.scala
+++ b/stargate-redis/test/integration/McSsoControllerSpec.scala
@@ -1,7 +1,6 @@
 package integration
 
 import javax.inject.Inject
-
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -17,7 +16,7 @@ import play.api.libs.json.{JsDefined, JsString}
 import play.api.mvc.{ControllerComponents, Session}
 import play.api.http.SessionConfiguration
 import com.salesforce.mce.stargate.controllers.McSsoController
-import com.salesforce.mce.stargate.models.{McSsoDecodedJwt, McSsoJwtRequestAdditionalClaims}
+import com.salesforce.mce.stargate.models.{McSsoDecodedJwt}
 import com.salesforce.mce.stargate.services.SessionTrackingService
 import com.salesforce.mce.stargate.services.impl.SessionTrackingServiceRedisImpl
 import com.salesforce.mce.stargate.utils.{JedisConnection, JwtUtil, JwtUtilImpl}
@@ -126,14 +125,10 @@ class McSsoControllerSpec extends PlaySpec with GuiceOneAppPerTest with BeforeAn
           val sessionPostLogin = Session(session.data ++ Map("meme" -> "i see what you did there"))
           val redirectUrlPostLogin = "https://www.reddit.com/r/corgi/"
 
-          mcSsoDecodedJwt.request.additionalClaims mustNot be(None)
-          val claims: McSsoJwtRequestAdditionalClaims = mcSsoDecodedJwt.request.additionalClaims.get
-          claims.additionalClaims.get.get("some") must be("thing")
-          claims.additionalClaims.get.get("another") must be("item")
+          mcSsoDecodedJwt.request.rest.mcAccessToken must be(Some("testAccessToken"))
 
           return Future.successful((sessionPostLogin, redirectUrlPostLogin))
         }
-
       }
 
       val appController = new AppMcSsoController(

--- a/stargate-redis/test/integration/McSsoControllerSpec.scala
+++ b/stargate-redis/test/integration/McSsoControllerSpec.scala
@@ -126,6 +126,7 @@ class McSsoControllerSpec extends PlaySpec with GuiceOneAppPerTest with BeforeAn
           val redirectUrlPostLogin = "https://www.reddit.com/r/corgi/"
 
           mcSsoDecodedJwt.request.rest.mcAccessToken must be(Some("testAccessToken"))
+          mcSsoDecodedJwt.request.rest.mcAccessTokenExp must be(Some(3555))
 
           return Future.successful((sessionPostLogin, redirectUrlPostLogin))
         }

--- a/stargate-redis/test/integration/McSsoControllerSpec.scala
+++ b/stargate-redis/test/integration/McSsoControllerSpec.scala
@@ -48,7 +48,7 @@ class McSsoControllerSpec extends PlaySpec with GuiceOneAppPerTest with BeforeAn
   "sso/mc/login" should {
     val request = FakeRequest(POST, "/sso/mc/login")
     val secretKey = "changeme"
-    val jwtPayload = new JwtUtilImpl(Configuration(ConfigFactory.load())).mockDecodedJwt
+    val jwtPayload = new JwtUtilImpl(Configuration(ConfigFactory.load())).mockDecodedJwt(true)
 
     "be a 303 with JWT" in {
       val jwt = Jwt.encode(jwtPayload, secretKey, JwtAlgorithm.HS256)

--- a/stargate-redis/test/integration/McSsoControllerSpec.scala
+++ b/stargate-redis/test/integration/McSsoControllerSpec.scala
@@ -1,30 +1,32 @@
 package integration
 
 import javax.inject.Inject
+
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.collection.immutable.Map
+
+import play.api.test.Helpers._
+import play.api.test._
+import play.api.Configuration
+import play.api.libs.json.{JsDefined, JsString}
+import play.api.mvc.{ControllerComponents, Session}
+import play.api.http.{SecretConfiguration, SessionConfiguration}
+import play.api.libs.crypto.{CSRFTokenSignerProvider, DefaultCookieSigner}
+import play.filters.csrf.{CSRFAddToken, CSRFConfig}
+
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.play._
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
-import play.api.test.Helpers._
-import play.api.test._
 import pdi.jwt.{Jwt, JwtAlgorithm}
-import play.api.Configuration
-import play.api.libs.json.{JsDefined, JsString}
-import play.api.mvc.{ControllerComponents, Session}
-import play.api.http.SessionConfiguration
+
 import com.salesforce.mce.stargate.controllers.McSsoController
 import com.salesforce.mce.stargate.models.{McSsoDecodedJwt}
 import com.salesforce.mce.stargate.services.SessionTrackingService
 import com.salesforce.mce.stargate.services.impl.SessionTrackingServiceRedisImpl
 import com.salesforce.mce.stargate.utils.{JedisConnection, JwtUtil, JwtUtilImpl}
-import play.api.http.{SecretConfiguration, SessionConfiguration}
-import play.api.libs.crypto.{CSRFTokenSignerProvider, DefaultCookieSigner}
-import play.filters.csrf.{CSRFAddToken, CSRFConfig}
-
-import scala.collection.immutable.Map
 
 class McSsoControllerSpec extends PlaySpec with GuiceOneAppPerTest with BeforeAndAfterEach {
   val config = Configuration(ConfigFactory.load())

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.14.4"
+version in ThisBuild := "0.14.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15"
+version in ThisBuild := "0.15.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.14.5"
+version in ThisBuild := "0.15"


### PR DESCRIPTION
This change adds the ability to optionally inject an external Marketing Cloud Access token into the McSsoJwtRequestRest claims section. If provided, the token and optional expiry for the token will be stored in the McSsoJwtRequestRest object and available for usage in the postLoginCallback method.

If the mcAccessToken is not provided - that's OK - should initialize to a None value.