### PR TITLE
Add TLS support for ElastiCache rediss:// URLs

### DIFF
--- a/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
+++ b/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
@@ -8,7 +8,6 @@
 package com.salesforce.mce.stargate.utils
 
 import java.net.URI
-import javax.net.ssl.SSLSocketFactory
 
 import scala.collection.JavaConverters
 
@@ -17,6 +16,58 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig
 import play.api.Configuration
 import redis.clients.jedis._
 
+/**
+ * Pure parsing of the configured redis cluster node URLs. Kept separate from
+ * [[JedisConnection]] so that it can be unit-tested without triggering the
+ * eager live connection that `JedisConnection.cluster` opens at class init.
+ */
+object RedisClusterConfig {
+
+  /** Parsed connection settings shared across every node of a cluster client. */
+  case class ClusterConfig(
+    nodes: Set[HostAndPort],
+    useSsl: Boolean,
+    password: Option[String]
+  )
+
+  // Extracts the password from a redis URI's userinfo. Userinfo is of the form
+  // `user:password` (ElastiCache AUTH-token URLs use the empty-user form
+  // `rediss://:token@host`). Split with a limit of 2 so that a password
+  // containing ':' is preserved, and tolerate userinfo with no ':' at all
+  // (returns None) rather than throwing.
+  def passwordOf(uri: URI): Option[String] =
+    Option(uri.getUserInfo).flatMap(_.split(":", 2) match {
+      case Array(_, password) => Some(password)
+      case _                  => None
+    })
+
+  def parse(urls: Seq[String]): ClusterConfig = {
+    val hostsAndPortsAndPasswords: Seq[(HostAndPort, Option[String], Boolean)] = urls.map { url =>
+      val uri = new URI(url)
+      val password = passwordOf(uri)
+      val ssl = uri.getScheme == "rediss"
+      (new HostAndPort(uri.getHost, uri.getPort), password, ssl)
+    }
+
+    // All node URLs must agree on the scheme: a single JedisCluster client config
+    // is shared across every node, so a mixed redis://+rediss:// config would
+    // silently apply the head node's TLS setting to all of them. Fail fast
+    // instead of producing an opaque plaintext-vs-TLS mismatch at runtime.
+    val distinctSchemes = hostsAndPortsAndPasswords.map(_._3).distinct
+    require(
+      distinctSchemes.size <= 1,
+      "com.salesforce.mce.stargate.redis.clusterNodeUrls mixes TLS (rediss://) and " +
+        "non-TLS (redis://) schemes; all cluster nodes must use the same scheme."
+    )
+
+    ClusterConfig(
+      nodes = hostsAndPortsAndPasswords.map(_._1).toSet,
+      useSsl = hostsAndPortsAndPasswords.headOption.exists(_._3),
+      password = hostsAndPortsAndPasswords.headOption.flatMap(_._2)
+    )
+  }
+}
+
 object JedisConnection {
   val defaultTimeoutMilis = 2000
   val defaultMaxAttempts = 5
@@ -24,38 +75,36 @@ object JedisConnection {
   val clusterNodeUrls = config.get[Seq[String]]("com.salesforce.mce.stargate.redis.clusterNodeUrls")
 
   val cluster: JedisCluster = {
-    val hostsAndPortsAndPasswords: Seq[(HostAndPort, Option[String], Boolean)] = clusterNodeUrls.map { url =>
-      val uri = new URI(url)
-      val password = Option(uri.getUserInfo).map(_.split(":")(1))
-      val ssl = uri.getScheme == "rediss"
-      (new HostAndPort(uri.getHost, uri.getPort), password, ssl)
-    }
-    val clusterNodes = JavaConverters.setAsJavaSet(hostsAndPortsAndPasswords.map(_._1).toSet)
-    val useSsl = hostsAndPortsAndPasswords.headOption.exists(_._3)
+    val parsed = RedisClusterConfig.parse(clusterNodeUrls)
 
     val clientConfig = DefaultJedisClientConfig.builder()
       .connectionTimeoutMillis(defaultTimeoutMilis)
       .socketTimeoutMillis(defaultTimeoutMilis)
-      .ssl(useSsl)
+      .ssl(parsed.useSsl)
 
-    hostsAndPortsAndPasswords(0)._2.foreach { password =>
+    parsed.password.foreach { password =>
       clientConfig.password(password)
     }
 
     new JedisCluster(
-      clusterNodes,
+      JavaConverters.setAsJavaSet(parsed.nodes),
       clientConfig.build(),
       defaultMaxAttempts,
       new GenericObjectPoolConfig[Connection]()
     )
   }
 
+  // For resetting redis in tests only, not for production use.
   def flushDB(): Unit = {
     clusterNodeUrls.foreach { url =>
       val uri = new URI(url)
       val ssl = uri.getScheme == "rediss"
       val jedis = if (ssl) {
-        new Jedis(uri, DefaultJedisClientConfig.builder().ssl(true).build())
+        // Carry the AUTH token through on the TLS branch; a rediss:// cluster
+        // with in-transit encryption typically also requires AUTH.
+        val sslConfig = DefaultJedisClientConfig.builder().ssl(true)
+        RedisClusterConfig.passwordOf(uri).foreach(sslConfig.password)
+        new Jedis(uri, sslConfig.build())
       } else {
         new Jedis(uri)
       }

--- a/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
+++ b/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
@@ -97,17 +97,10 @@ object JedisConnection {
   // For resetting redis in tests only, not for production use.
   def flushDB(): Unit = {
     clusterNodeUrls.foreach { url =>
-      val uri = new URI(url)
-      val ssl = uri.getScheme == "rediss"
-      val jedis = if (ssl) {
-        // Carry the AUTH token through on the TLS branch; a rediss:// cluster
-        // with in-transit encryption typically also requires AUTH.
-        val sslConfig = DefaultJedisClientConfig.builder().ssl(true)
-        RedisClusterConfig.passwordOf(uri).foreach(sslConfig.password)
-        new Jedis(uri, sslConfig.build())
-      } else {
-        new Jedis(uri)
-      }
+      // new Jedis(URI) derives both the TLS setting (from a rediss:// scheme)
+      // and the AUTH token (from the URI userinfo) on its own, so no manual
+      // ssl/password wiring is needed here.
+      val jedis = new Jedis(new URI(url))
       try {
         jedis.flushDB()
       } finally {

--- a/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
+++ b/stargate-redis/app/com/salesforce/mce/stargate/utils/JedisConnection.scala
@@ -8,6 +8,7 @@
 package com.salesforce.mce.stargate.utils
 
 import java.net.URI
+import javax.net.ssl.SSLSocketFactory
 
 import scala.collection.JavaConverters
 
@@ -17,44 +18,52 @@ import play.api.Configuration
 import redis.clients.jedis._
 
 object JedisConnection {
-  // follow the default values at
-  // https://github.com/xetorthio/jedis/blob/master/src/main/java/redis/clients/jedis/BinaryJedisCluster.java#L26
   val defaultTimeoutMilis = 2000
   val defaultMaxAttempts = 5
   val config = Configuration(ConfigFactory.load())
   val clusterNodeUrls = config.get[Seq[String]]("com.salesforce.mce.stargate.redis.clusterNodeUrls")
 
   val cluster: JedisCluster = {
-    val hostsAndPortsAndPasswords: Seq[(HostAndPort, Option[String])] = clusterNodeUrls.map { url =>
+    val hostsAndPortsAndPasswords: Seq[(HostAndPort, Option[String], Boolean)] = clusterNodeUrls.map { url =>
       val uri = new URI(url)
       val password = Option(uri.getUserInfo).map(_.split(":")(1))
-      (new HostAndPort(uri.getHost, uri.getPort), password)
+      val ssl = uri.getScheme == "rediss"
+      (new HostAndPort(uri.getHost, uri.getPort), password, ssl)
     }
     val clusterNodes = JavaConverters.setAsJavaSet(hostsAndPortsAndPasswords.map(_._1).toSet)
-    hostsAndPortsAndPasswords(0)._2 match {
-      case Some(password) => new JedisCluster(
-        clusterNodes,
-        defaultTimeoutMilis,
-        defaultTimeoutMilis,
-        defaultMaxAttempts,
-        password,
-        new GenericObjectPoolConfig[Connection]()
-      )
-      case _ => new JedisCluster(
-        clusterNodes,
-        defaultTimeoutMilis,
-        defaultTimeoutMilis,
-        defaultMaxAttempts,
-        new GenericObjectPoolConfig[Connection]()
-      )
+    val useSsl = hostsAndPortsAndPasswords.headOption.exists(_._3)
+
+    val clientConfig = DefaultJedisClientConfig.builder()
+      .connectionTimeoutMillis(defaultTimeoutMilis)
+      .socketTimeoutMillis(defaultTimeoutMilis)
+      .ssl(useSsl)
+
+    hostsAndPortsAndPasswords(0)._2.foreach { password =>
+      clientConfig.password(password)
     }
+
+    new JedisCluster(
+      clusterNodes,
+      clientConfig.build(),
+      defaultMaxAttempts,
+      new GenericObjectPoolConfig[Connection]()
+    )
   }
 
-  // Jedis cluster does not implement flushDB so this calls .flushDB on each of individual node.
-  // This is a convenient method for resetting redis in tests only, not for production.
   def flushDB(): Unit = {
     clusterNodeUrls.foreach { url =>
-      val result = new Jedis(new URI(url)).flushDB()
+      val uri = new URI(url)
+      val ssl = uri.getScheme == "rediss"
+      val jedis = if (ssl) {
+        new Jedis(uri, DefaultJedisClientConfig.builder().ssl(true).build())
+      } else {
+        new Jedis(uri)
+      }
+      try {
+        jedis.flushDB()
+      } finally {
+        jedis.close()
+      }
     }
   }
 }

--- a/stargate-redis/test/com/salesforce/mce/stargate/utils/RedisClusterConfigSpec.scala
+++ b/stargate-redis/test/com/salesforce/mce/stargate/utils/RedisClusterConfigSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.mce.stargate.utils
+
+import java.net.URI
+
+import org.scalatestplus.play.PlaySpec
+
+class RedisClusterConfigSpec extends PlaySpec {
+
+  "passwordOf" should {
+
+    "extract the password from the empty-user ElastiCache AUTH form" in {
+      RedisClusterConfig.passwordOf(new URI("rediss://:my-token@host:6379")) mustBe Some("my-token")
+    }
+
+    "extract the password from the user:password form" in {
+      RedisClusterConfig.passwordOf(new URI("redis://user:secret@host:6379")) mustBe Some("secret")
+    }
+
+    "preserve a password that itself contains a colon" in {
+      RedisClusterConfig.passwordOf(new URI("rediss://:tok:en:123@host:6379")) mustBe Some("tok:en:123")
+    }
+
+    "return None when there is no userinfo" in {
+      RedisClusterConfig.passwordOf(new URI("redis://host:6379")) mustBe None
+    }
+
+    "return None (rather than throw) when userinfo has no colon" in {
+      RedisClusterConfig.passwordOf(new URI("redis://tokenonly@host:6379")) mustBe None
+    }
+  }
+
+  "parse" should {
+
+    "detect TLS from a rediss:// scheme" in {
+      val parsed = RedisClusterConfig.parse(Seq("rediss://:token@h1:6379"))
+      parsed.useSsl mustBe true
+      parsed.password mustBe Some("token")
+    }
+
+    "leave TLS off for a plain redis:// scheme (backward compatibility)" in {
+      val parsed = RedisClusterConfig.parse(Seq("redis://h1:6379"))
+      parsed.useSsl mustBe false
+      parsed.password mustBe None
+    }
+
+    "collect every node into the host set" in {
+      val parsed = RedisClusterConfig.parse(
+        Seq("rediss://:t@h1:6379", "rediss://:t@h2:6380", "rediss://:t@h3:6381")
+      )
+      parsed.nodes.map(hp => (hp.getHost, hp.getPort)) mustBe
+        Set(("h1", 6379), ("h2", 6380), ("h3", 6381))
+    }
+
+    "accept a uniformly rediss:// cluster" in {
+      val parsed = RedisClusterConfig.parse(Seq("rediss://:t@h1:6379", "rediss://:t@h2:6380"))
+      parsed.useSsl mustBe true
+    }
+
+    "reject a cluster that mixes redis:// and rediss:// schemes" in {
+      val thrown = the[IllegalArgumentException] thrownBy {
+        RedisClusterConfig.parse(Seq("rediss://:t@h1:6379", "redis://h2:6380"))
+      }
+      thrown.getMessage must include("same scheme")
+    }
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.17.0"
+ThisBuild / version := "0.18.0"


### PR DESCRIPTION
Uses DefaultJedisClientConfig with ssl=true when URI scheme is rediss://, enabling connectivity to ElastiCache with transit encryption enabled.